### PR TITLE
Allow for options to broccoli-sass filter.

### DIFF
--- a/lib/site.js
+++ b/lib/site.js
@@ -96,13 +96,14 @@ Site.prototype.staticFiles = function () {
 };
 
 Site.prototype.scss = function () {
+  var options = this.options.sass || {};
   if (this.scssFiles.length) {
     this.scssTree = this.pickFiles(this.tree, 'scss');
   }
 
   var trees = this.scssFiles.map(function (file) {
     var name = file.replace(/\.scss$/, '.css').replace(/pages/, '');
-    var css = sass([this.scssTree], file, name);
+    var css = sass([this.scssTree], file, name, options);
 
     css = this.compressCss(css);
     css = this.base64CSS(css);


### PR DESCRIPTION
Bootstrap-sass [requires SASS precision to be at least 8](https://github.com/twbs/bootstrap-sass/issues/409). Then we need to be able to set it at compile time. With this patch I can pass a `sass` object as an option to broccoli-taco.