### PR TITLE
Files in static folder are not copied.

### DIFF
--- a/lib/site.js
+++ b/lib/site.js
@@ -21,7 +21,7 @@ var sass             = projectRequire('broccoli-sass');
 var uglifyJavaScript = projectRequire('broccoli-uglify-js');
 
 var mergeTrees       = require('broccoli-merge-trees');
-var pickFiles        = require('broccoli-static-compiler');
+var pickFiles        = require('broccoli-funnel');
 var UnwatchedTree    = require('broccoli-unwatched-tree');
 var handlebars       = require('./broccoli-taco-handlebars');
 var Handlebars       = require('handlebars');
@@ -83,15 +83,16 @@ Site.prototype.pickFiles = function (tree, extensions) {
  if ('string' === typeof extensions) extensions = [extensions];
  return pickFiles(tree, {
     srcDir: '/'
-  , files: extensions.map(function (ext) { return '**/*.'+ext; })
+  , include: extensions.map(function (ext) { return '**/*.'+ext; })
   , destDir: '/'
   });
 };
 
 Site.prototype.staticFiles = function () {
   return pickFiles(this.tree, {
-    srcDir: '/static'
-  , destDir: '/static'
+    srcDir: 'static'
+  , include: ['**/*']
+  , destDir: 'static'
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "license": "MIT",
   "dependencies": {
     "broccoli": "^0.16.0",
+    "broccoli-funnel": "^0.2.3",
     "broccoli-handlebars": "0.0.6",
     "broccoli-kitchen-sink-helpers": "^0.2.6",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-sane-watcher": "1.0.2",
-    "broccoli-static-compiler": "^0.2.1",
     "broccoli-unwatched-tree": "^0.1.1",
     "chalk": "^1.0.0",
     "clone": "^1.0.2",


### PR DESCRIPTION
First of all: broccoli-static-compiler is deprecated by broccoli-funnel.
That is why I have replaced it in the dependencies.

However the reason for this patch is that, in my project, the static
folder was empty.

I'm not sure if this is a bug in broccoli-funnel. However it looks like
subsequent calls to the filter, inherit the options used in previous
calls. We need then to be explicit on what to include because a filter
on file names was set by previous calls to the filter.