### PR TITLE
Feature/fix require cache

### DIFF
--- a/lib/render-context.js
+++ b/lib/render-context.js
@@ -10,6 +10,7 @@ var RenderContext = module.exports = function (options) {
 
 RenderContext.prototype.getData = function (path) {
   try {
+    delete require.cache[require.resolve(path)];
     var data = require(path);
     if ('object' === typeof data) return data;
     return Promise.resolve(data());
@@ -33,6 +34,7 @@ RenderContext.prototype.assetsData = function () {
   var manifest = this.manifest;
   if (!manifest) return {};
   manifest = path.join(manifest.tmpDestDir, manifest.name);
+  delete require.cache[require.resolve(manifest)];
   return require(manifest);
 };
 

--- a/lib/site.js
+++ b/lib/site.js
@@ -31,9 +31,9 @@ var walkSync         = require('walk-sync');
 var requireDir       = require('require-dir');
 var RenderContext    = require('./render-context');
 
-var SCSS_ASSET = /(site|page)\.scss$/;
-var CSS_ASSET = /(site|page)\.css$/;
-var JAVASCRIPT_ASSET = /(site|page)\.js/;
+var SCSS_ASSET = /^(site|page)\.scss$/;
+var CSS_ASSET = /^(site|page)\.css$/;
+var JAVASCRIPT_ASSET = /^(site|page)\.js/;
 
 function filter (regex) {
   return function (str) {


### PR DESCRIPTION
This fixes the instances where changes to CSS and JS causes a new manifest file to be written but not read back properly in the build process causing the site to break. This is due to the fact that `require` caches any successful file loads.